### PR TITLE
feat: option interface to enable and disable HTML minifier

### DIFF
--- a/render/html.go
+++ b/render/html.go
@@ -12,10 +12,11 @@ import (
 )
 
 type Page struct {
-	context *plush.Context
-	writer  http.ResponseWriter
-	fs      fs.FS
-	minify  *minify.M
+	context      *plush.Context
+	writer       http.ResponseWriter
+	fs           fs.FS
+	minify       *minify.M
+	minifyEnable bool
 
 	defaultLayout string
 }
@@ -46,20 +47,27 @@ func (p *Page) Render(page string) error {
 		return fmt.Errorf("[render.render] - error on find default layout from the fs: %w", err)
 	}
 
-	layout = strings.Replace(layout, "<%= Wyield %>", html, 1)
+	layout = strings.Replace(layout, "<%= Tyield %>", html, 1)
 	html, err = plush.Render(layout, p.context)
 	if err != nil {
 		return err
 	}
 
-	shtml, err := p.minify.String("text/html", html)
-	if err != nil {
-		return fmt.Errorf("failed to minify html: %w", err)
+	if p.minifyEnable {
+		shtml, err := p.minify.String("text/html", html)
+		if err != nil {
+			return fmt.Errorf("failed to minify html: %w", err)
+		}
+
+		_, err = p.writer.Write([]byte(shtml))
+		if err != nil {
+			return fmt.Errorf("could not write to response minify: %w", err)
+		}
 	}
 
-	_, err = p.writer.Write([]byte(shtml))
+	_, err = p.writer.Write([]byte(html))
 	if err != nil {
-		return fmt.Errorf("could not write to response: %w", err)
+		return fmt.Errorf("could not write to response non minify: %w", err)
 	}
 
 	return nil
@@ -87,14 +95,21 @@ func (p *Page) RenderWithLayout(page, layout string) error {
 		return err
 	}
 
-	shtml, err := p.minify.String("text/html", html)
-	if err != nil {
-		return fmt.Errorf("failed to minify html: %w", err)
+	if p.minifyEnable {
+		shtml, err := p.minify.String("text/html", html)
+		if err != nil {
+			return fmt.Errorf("failed to minify html: %w", err)
+		}
+
+		_, err = p.writer.Write([]byte(shtml))
+		if err != nil {
+			return fmt.Errorf("could not write to response minify: %w", err)
+		}
 	}
 
-	_, err = p.writer.Write([]byte(shtml))
+	_, err = p.writer.Write([]byte(html))
 	if err != nil {
-		return fmt.Errorf("could not write to response: %w", err)
+		return fmt.Errorf("could not write to response non minify: %w", err)
 	}
 
 	return nil
@@ -112,14 +127,21 @@ func (p *Page) RenderClean(name string) error {
 		return err
 	}
 
-	shtml, err := p.minify.String("text/html", html)
-	if err != nil {
-		return fmt.Errorf("failed to minify html: %w", err)
+	if p.minifyEnable {
+		shtml, err := p.minify.String("text/html", html)
+		if err != nil {
+			return fmt.Errorf("failed to minify html: %w", err)
+		}
+
+		_, err = p.writer.Write([]byte(shtml))
+		if err != nil {
+			return fmt.Errorf("could not write to response minify: %w", err)
+		}
 	}
 
-	_, err = p.writer.Write([]byte(shtml))
+	_, err = p.writer.Write([]byte(html))
 	if err != nil {
-		return fmt.Errorf("could not write to response: %w", err)
+		return fmt.Errorf("could not write to response non minify: %w", err)
 	}
 
 	return nil

--- a/render/options.go
+++ b/render/options.go
@@ -4,6 +4,20 @@ import "html/template"
 
 type Option func(*Engine)
 
+type MinifierHTMLConfig struct {
+	KeepComments            bool
+	KeepConditionalComments bool
+	KeepDefaultAttrVals     bool
+	KeepDocumentTags        bool
+	KeepEndTags             bool
+	KeepQuotes              bool
+	KeepWhitespace          bool
+}
+type MinifierOption struct {
+	Enable bool
+	HTML   MinifierHTMLConfig
+}
+
 // WithDefaultLayout sets the default layout for the engine
 // Default to components/index.html
 func WithDefaultLayout(layout string) Option {
@@ -25,5 +39,20 @@ func WithHelpers(hps template.FuncMap) Option {
 func WithValues(values map[string]any) Option {
 	return func(e *Engine) {
 		e.values = values
+	}
+}
+
+// WithMinifier sets minifier configuration
+// Available globally. e.g: map[string]any{ "key": "value" })
+func WithMinifier(values MinifierOption) Option {
+	return func(e *Engine) {
+		e.minifier.Enable = values.Enable
+		e.minifier.HTML.KeepComments = values.HTML.KeepComments
+		e.minifier.HTML.KeepConditionalComments = values.HTML.KeepConditionalComments
+		e.minifier.HTML.KeepDefaultAttrVals = values.HTML.KeepDefaultAttrVals
+		e.minifier.HTML.KeepDocumentTags = values.HTML.KeepDocumentTags
+		e.minifier.HTML.KeepEndTags = values.HTML.KeepEndTags
+		e.minifier.HTML.KeepQuotes = values.HTML.KeepQuotes
+		e.minifier.HTML.KeepWhitespace = values.HTML.KeepWhitespace
 	}
 }


### PR DESCRIPTION
## Description

In the previous version, minifier will always enabled by default. This version will add interface to enable or disable minifier. Help user to decide wether need enable minifier, such as disable in development for debugging purpose.

## Implementation

```go
  import "github.com/devetek/go-core/render"


view := render.NewEngine(
  internal.Template,
  render.WithValues(
	  map[string]any{
		  "keywords": "Golang template ejs style",
	  }),
  render.WithDefaultLayout(cfg.GetString("view.default")),
  render.WithMinifier(render.MinifierOption{
	  Enable: false,
	  HTML: render.MinifierHTMLConfig{
		  KeepWhitespace:      false,
		  KeepDefaultAttrVals: true,
		  KeepDocumentTags:    true,
		  KeepEndTags:         true,
		  KeepQuotes:          false,
	  },
  }),
)
```